### PR TITLE
Implement seeding the database with EFCore.BulkExtensions

### DIFF
--- a/CursorPaging.Benchmark/Program.cs
+++ b/CursorPaging.Benchmark/Program.cs
@@ -39,6 +39,22 @@ try
     stopwatch.Start();
     var db = new Database();
     db.ChangeTracker.AutoDetectChangesEnabled = false;
+
+    await Database.SeedPicturesWithBulkExtensions(db, "with EFCore.BulkExtensions");
+    stopwatch.Stop();
+    AnsiConsole.WriteLine($"With EFCore.BulkExtensions: {stopwatch.Elapsed.TotalSeconds} seconds");
+}
+catch (Exception ex)
+{
+    AnsiConsole.WriteException(ex);
+}
+
+try
+{
+    DeleteIfExists("pictures.db");
+    stopwatch.Start();
+    var db = new Database();
+    db.ChangeTracker.AutoDetectChangesEnabled = false;
     
     await Database.SeedPictures(db, "without transaction scope");
     stopwatch.Stop();

--- a/CursorPaging.Data/CursorPaging.Data.csproj
+++ b/CursorPaging.Data/CursorPaging.Data.csproj
@@ -6,11 +6,12 @@
 
     <ItemGroup>
       <PackageReference Include="Bogus" Version="33.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.7">
+      <PackageReference Include="EFCore.BulkExtensions" Version="5.4.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.12">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.12" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" />
         <PackageReference Include="Spectre.Console" Version="0.40.0" />
     </ItemGroup>


### PR DESCRIPTION
In my test, seeding with EFCore.BulkExtensions is ~2×  slower than fastest method (SeedPicturesWithCommand) which is still waaaaay faster than the standard EFCore AddRange method.

On the plus side, it's literally a one-liner on the DbContext.

Under the hood, it dynamically generates SQL and executes it, just like SeedPicturesWithCommand but with a little bit more overhead.